### PR TITLE
Delint for MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,58 @@
+# Ignore build directories
+/build/
+/out/
+/bin/
+/lib/
+/obj/
+
+# Ignore build tools and temporary files
+CMakeFiles/
+CMakeCache.txt
+Makefile
+CMakeLists.txt.user
+*.cmake
+*.o
+*.obj
+*.so
+*.dll
+*.dylib
+*.exe
+*.a
+*.lib
+
+# Ignore generated files
+*.class
+*.gen.cpp
+*.moc.cpp
+*.moc
+*.qrc
+*.rcc
+
+# Ignore log and debugging files
+*.log
+*.tmp
+*.bak
+*.swp
+*.swo
+*.pid
+
+# Ignore IDE/editor-specific files
+.idea/
+.vscode/
+*.code-workspace
+*.sln
+*.vcxproj*
+*.user
+*.DS_Store
+*.vscode/
+*.vs/
+Thumbs.db
+
+# Ignore system files
+*.gz
+*.zip
+*.tar.gz
+*.tar.bz2
+*.tgz
+*.tar.xz
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,71 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(EzGz LANGUAGES CXX)
+
+# Allow overriding the C++ standard via command line (default is C++20)
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 20)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF) # Use -std=c++XX instead of -std=gnu++XX
+
+message(STATUS "Compiling for C++" ${CMAKE_CXX_STANDARD})
+
+# Detect compiler type
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        message(STATUS "Detected AppleClang on macOS")
+    else()
+        message(STATUS "Detected Clang")
+    endif()
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+    message(STATUS "Detected AppleClang on macOS")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    message(STATUS "Detected GCC")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    message(STATUS "Detected MSVC on Windows")
+else()
+    message(STATUS "Using unknown compiler")
+endif()
+
+# Compiler-specific options
+if (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang|Clang|GNU")
+    # Extra warnings for Clang/AppleClang
+    set(WARNING_OPTIONS "-Wall" "-Wextra" "-Wpedantic")
+    set(DEBUG_FLAGS "-g")
+    # Suppress unknown attribute warning when compiling for C++17
+    if (CMAKE_CXX_STANDARD STREQUAL "17")
+        message(STATUS "Suppressing C++20 warnings for C++17")
+        list(APPEND WARNING_OPTIONS "-Wno-c++20-extensions")
+    endif()
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    # Extra warnings for MSVC
+    set(WARNING_OPTIONS "/W4")
+    set(DEBUG_FLAGS "/Zi")
+    # Enable proper reporting of __cplusplus in MSVC
+    add_compile_options(/Zc:__cplusplus)    
+    # Suppress unknown attribute warning when compiling for C++17
+    if (CMAKE_CXX_STANDARD STREQUAL "17")
+        message(STATUS "Suppressing C++20 warnings for C++17")
+        list(APPEND WARNING_OPTIONS "/wd5051")
+    endif()
+endif()
+
+# Set output directory for executables
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+# Add executables
+add_executable(ezgz_test ezgz_test.cpp)
+add_executable(ezgz_decompress ezgz_decompress.cpp)
+
+# Apply compiler options
+if (WARNING_OPTIONS)
+    target_compile_options(ezgz_test PRIVATE ${WARNING_OPTIONS} ${DEBUG_FLAGS})
+    target_compile_options(ezgz_decompress PRIVATE ${WARNING_OPTIONS} ${DEBUG_FLAGS})
+endif()
+
+# Add threading support
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+target_link_libraries(ezgz_test PRIVATE Threads::Threads)
+target_link_libraries(ezgz_decompress PRIVATE Threads::Threads)

--- a/ezgz.hpp
+++ b/ezgz.hpp
@@ -807,7 +807,7 @@ class DeflateReader {
 					if (code.code < 144) {
 						parent->output.addByte(static_cast<char>(code.code));
 					} else {
-						uint8_t full = ((code.code - 144)) << 1 + 144 + input.getBits(1);
+						uint8_t full = static_cast<uint8_t>(((code.code - 144) << 1) + 144 + input.getBits(1));
 						parent->output.addByte(full);
 					}
 				}

--- a/ezgz.hpp
+++ b/ezgz.hpp
@@ -38,7 +38,9 @@ public:
     span(T* ptr, std::size_t size) : m_ptr(ptr), m_size(size) {}
     span(T* begin, T* end) : m_ptr(begin), m_size(std::distance(begin, end)) {}
     template <typename It>
-    span(It begin, It end) : m_ptr(&(*begin)), m_size(std::distance(begin, end)) {}
+    span(It begin, It end) :
+			m_ptr(begin == end ? nullptr : &(*begin)),
+			m_size(std::distance(begin, end)) {}
     template <std::size_t N>
     span(const std::array<std::remove_const_t<T>, N>& arr) : m_ptr(arr.data()), m_size(N) {}
 
@@ -180,7 +182,7 @@ public:
 	uint32_t operator() () { return ~state; }
 	uint32_t operator() (std::span<const uint8_t> input) {
 		for (auto it : input) {
-			const uint8_t tableIndex = static_cast<uint8_t>(state ^ it);
+			const uint8_t tableIndex = uint8_t(state ^ it);
 			state = (state >> 8) ^ Detail::basicCrc32LookupTable[tableIndex];
 		}
 		return ~state; // Invert all bits at the end
@@ -235,7 +237,7 @@ public:
 		}
 
 		for ( ; position < std::ssize(input); position++) {
-			const uint8_t tableIndex = static_cast<uint8_t>(state ^ input[position]);
+			const uint8_t tableIndex = uint8_t(state ^ input[position]);
 			state = (state >> 8) ^ Detail::basicCrc32LookupTable[tableIndex];
 		}
 		return ~state; // Invert all bits at the end
@@ -310,7 +312,7 @@ public:
 			refillSome();
 		}
 		ptrdiff_t start = position;
-		int available = std::min<int>(size, filled - static_cast<int>(start));
+		int available = std::min<int>(size, filled - int(start));
 		position += available;
 		return {buffer.begin() + start, buffer.begin() + start + available};
 	}
@@ -371,7 +373,7 @@ class BitReader {
 			};
 			dataAdded.number <<= bitsLeft;
 			data += dataAdded.number;
-			bitsLeft += static_cast<int>(added.size() << 3);
+			bitsLeft += int(added.size() << 3);
 		}
 	}
 
@@ -406,7 +408,7 @@ public:
 		if (bitsLeft < amount) [[unlikely]] {
 			throw std::runtime_error("Run out of data");
 		}
-		uint16_t result = static_cast<uint16_t>(data);
+		uint16_t result = uint16_t(data);
 		data >>= amount;
 		bitsLeft -= amount;
 		result &= upperRemovals[amount];
@@ -417,7 +419,7 @@ public:
 	template <typename ReadAndTellHowMuchToConsume>
 	void peekAByteAndConsumeSome(const ReadAndTellHowMuchToConsume& readAndTellHowMuchToConsume) {
 		refillIfNeeded();
-		uint8_t pulled = static_cast<uint8_t>(data);
+		uint8_t pulled = uint8_t(data);
 		auto consumed = readAndTellHowMuchToConsume(pulled);
 		if (bitsLeft < consumed) [[unlikely]] {
 			throw std::runtime_error("Run out of data");
@@ -469,7 +471,7 @@ class ByteOutput {
 
 public:
 	int available() {
-		return static_cast<int>(buffer.size() - used);
+		return int(buffer.size() - used);
 	}
 
 	std::span<const char> consume(const int bytesToKeep = 0) {
@@ -509,9 +511,9 @@ public:
 	}
 
 	void addBytes(std::span<const char> bytes) {
-		checkSize(static_cast<int>(bytes.size()));
+		checkSize(int(bytes.size()));
 		memcpy(buffer.data() + used, bytes.data(), bytes.size());
-		used += static_cast<int>(bytes.size());
+		used += int(bytes.size());
 	}
 
 	void repeatSequence(int length, int distance) {
@@ -573,7 +575,7 @@ public:
 				return codeCodingLengths[length];
 			});
 			if (length < 16) {
-				codes[i].length = static_cast<uint8_t>(length);
+				codes[i].length = uint8_t(length);
 				i++;
 				quantities[length]++;
 			} else if (length == 16) {
@@ -619,8 +621,8 @@ public:
 						if (size <= 8) [[likely]] {
 							codes[i].start = reversedBytes[firstPart];
 							for (int code = codes[i].start >> (8 - size); code < std::ssize(codesIndex); code += (1 << size)) {
-								codesIndex[code].word = static_cast<int16_t>(i);
-								codesIndex[code].length = static_cast<int8_t>(size);
+								codesIndex[code].word = int16_t(i);
+								codesIndex[code].length = int8_t(size);
 								codesIndex[code].valid = true;
 							}
 						} else {
@@ -650,11 +652,11 @@ public:
 			if (code.length > 8) {
 				UnindexedEntry& unindexedEntry = unindexedEntries[code.start];
 				CodeRemainder& remainder = remainders[unindexedEntry.startIndex + unindexedEntry.filled];
-				codesIndex[code.start].word = static_cast<int16_t>(MaxSize + unindexedEntry.startIndex);
+				codesIndex[code.start].word = int16_t(MaxSize + unindexedEntry.startIndex);
 				unindexedEntry.filled++;
 				remainder.remainder = code.ending; // The upper bits are cut
 				remainder.bitsLeft = code.length - 8;
-				remainder.index = static_cast<uint16_t>(i);
+				remainder.index = uint16_t(i);
 				if (unindexedEntry.filled == unindexedEntry.quantity)
 					remainder.index |= 0x8000;
 			}
@@ -727,8 +729,8 @@ class DeflateReader {
 	struct LiteralState {
 		int bytesLeft = 0;
 		LiteralState(DeflateReader* parent) {
-			int length = static_cast<int>(parent->input.getBytes(2));
-			int antiLength = static_cast<int>(parent->input.getBytes(2));
+			int length = int(parent->input.getBytes(2));
+			int antiLength = int(parent->input.getBytes(2));
 			if ((~length & 0xffff) != antiLength) {
 				throw std::runtime_error("Corrupted data, inverted length of literal block is mismatching");
 			}
@@ -739,11 +741,11 @@ class DeflateReader {
 			if (parent->output.available() > bytesLeft) {
 				std::span<const uint8_t> chunk = parent->input.getRange(bytesLeft);
 				parent->output.addBytes(std::span<const char>(reinterpret_cast<const char*>(chunk.data()), (chunk.size())));
-				bytesLeft -= static_cast<int>(chunk.size());
+				bytesLeft -= int(chunk.size());
 				return (bytesLeft > 0);
 			} else {
 				std::span<const uint8_t> chunk = parent->input.getRange(parent->output.available());
-				bytesLeft -= static_cast<int>(chunk.size());
+				bytesLeft -= int16_t(chunk.size());
 				parent->output.addBytes(std::span<const char>(reinterpret_cast<const char*>(chunk.data()), (chunk.size())));
 				return true;
 			}
@@ -805,9 +807,9 @@ class DeflateReader {
 					CopyState::copy(parent->output, length, distance);
 				} else {
 					if (code.code < 144) {
-						parent->output.addByte(static_cast<char>(code.code));
+						parent->output.addByte(char(code.code));
 					} else {
-						uint8_t full = static_cast<uint8_t>(((code.code - 144) << 1) + 144 + input.getBits(1));
+						uint8_t full = uint8_t(((code.code - 144) << 1) + 144 + input.getBits(1));
 						parent->output.addByte(full);
 					}
 				}
@@ -838,7 +840,7 @@ class DeflateReader {
 				int word = codes.readWord();
 
 				if (word < 256) {
-					parent->output.addByte(static_cast<char>(word));
+					parent->output.addByte(char(word));
 				} else if (word == 256) [[unlikely]] {
 					break;
 				} else {
@@ -917,7 +919,7 @@ public:
 				// Read Huffman code lengths
 				std::array<uint8_t, codeCodingReorder.size()> codeCodingLengths = {};
 				for (int i = 0; i < codeLengthCount; i++) {
-					codeCodingLengths[codeCodingReorder[i]] = static_cast<uint8_t>(bitInput.getBits(3));
+					codeCodingLengths[codeCodingReorder[i]] = uint8_t(bitInput.getBits(3));
 				}
 
 				// Generate Huffman codes for lengths
@@ -929,7 +931,7 @@ public:
 						if (codeCodingLengths[i] == size) {
 
 							for (int code = nextCodeCoding << (8 - size); code < (nextCodeCoding + 1) << (8 - size); code++) {
-								codeCodingLookup[reversedBytes[code]] = static_cast<uint8_t>(i);
+								codeCodingLookup[reversedBytes[code]] = uint8_t(i);
 							}
 							codeCoding[i] = reversedBytes[nextCodeCoding];
 
@@ -967,7 +969,7 @@ std::vector<char> readDeflateIntoVector(std::function<int(std::span<uint8_t> bat
 template <DecompressionSettings Settings = DefaultDecompressionSettings>
 std::vector<char> readDeflateIntoVector(std::span<const uint8_t> allData) {
 	return readDeflateIntoVector<Settings>([allData, position = 0] (std::span<uint8_t> toFill) mutable -> int {
-		int filling = static_cast<int>(std::min(allData.size() - position, toFill.size()));
+		int filling = int(std::min(allData.size() - position, toFill.size()));
 		if(filling != 0)
 			memcpy(toFill.data(), &allData[position], filling);
 		position += filling;
@@ -995,7 +997,7 @@ public:
 			throw std::runtime_error("Can't read file");
 		}
 		file->read(reinterpret_cast<char*>(batch.data()), batch.size());
-		int bytesRead = static_cast<int>(file->gcount());
+		int bytesRead = int(file->gcount());
 		if (bytesRead == 0) {
 			throw std::runtime_error("Truncated file");
 		}
@@ -1004,7 +1006,7 @@ public:
 #endif
 
 	IDeflateArchive(std::span<const uint8_t> data) : input([data] (std::span<uint8_t> batch) mutable {
-		int copying = static_cast<int>(std::min(batch.size(), data.size()));
+		int copying = int(std::min(batch.size(), data.size()));
 		if (copying == 0) {
 			throw std::runtime_error("Truncated input");
 		}
@@ -1044,7 +1046,7 @@ public:
 					wasSeparator = true;
 				}
 			}
-			keeping = static_cast<int>(batch.end() - start);
+			keeping = int(batch.end() - start);
 		}
 		if (keeping > 0) {
 			if (wasSeparator)
@@ -1129,7 +1131,7 @@ struct IGzFileInfo {
 				std::span<const uint8_t> taken = input.getRange(extraHeaderSize - readSoFar);
 				checksum(taken);
 				extraData->insert(extraData->end(), taken.begin(), taken.end());
-				readSoFar += static_cast<int>(taken.size());
+				readSoFar += int(taken.size());
 			}
 		}
 		if (flags & 0x08) {
@@ -1156,7 +1158,7 @@ struct IGzFileInfo {
 		if (flags & 0x02) {
 			uint16_t expectedHeaderCrc = input.template getInteger<uint16_t>();
 			check(expectedHeaderCrc);
-			uint16_t realHeaderCrc = static_cast<uint16_t>(checksum());
+			uint16_t realHeaderCrc = uint16_t(checksum());
 			if (expectedHeaderCrc != realHeaderCrc)
 				throw std::runtime_error("Gzip archive's headers crc32 checksum doesn't match the actual header's checksum");
 		}

--- a/ezgz_decompress.cpp
+++ b/ezgz_decompress.cpp
@@ -4,6 +4,11 @@
 #include <filesystem>
 #include <chrono>
 
+#ifdef _WIN32
+#include <basetsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 // For testing purposes only, gunzip is faster because it can write into files much more efficiently
 
 int main(int argc, char** argv) {

--- a/ezgz_test.cpp
+++ b/ezgz_test.cpp
@@ -18,7 +18,7 @@ template <int Size>
 struct InputHelper : EzGz::Detail::ByteInput<SettingsWithInputSize<Size>> {
 	InputHelper(std::span<const uint8_t> source)
 	: EzGz::Detail::ByteInput<SettingsWithInputSize<Size>>([source, position = 0] (std::span<uint8_t> toFill) mutable -> int {
-		int filling = std::min(source.size() - position, toFill.size());
+		int filling = static_cast<int>(std::min(source.size() - position, toFill.size()));
 //		std::cout << "Providing " << filling << " bytes of data, " << (source.size() - position - filling) << " left" << std::endl;
 		if(filling != 0)
 			memcpy(toFill.data(), &source[position], filling);
@@ -64,7 +64,7 @@ int main(int, char**) {
 		}
 
 		{
-			unsigned int twoBytes = byteReader.getBytes(2);
+			unsigned int twoBytes = static_cast<unsigned int>(byteReader.getBytes(2));
 			doATest(twoBytes, 0b1010101010101010u);
 		}
 
@@ -94,7 +94,7 @@ int main(int, char**) {
 			while (read < tryingToRead) {
 				auto readTenBytes = reader.getRange(tryingToRead - read);
 				doATest(readTenBytes.size() < tryingToRead, true);
-				read += readTenBytes.size();
+				read += static_cast<int>(readTenBytes.size());
 			}
 			doATest(read, tryingToRead);
 		}
@@ -231,8 +231,8 @@ int main(int, char**) {
 		auto inspectStart = [&doATest, shouldBe, position = 0] (std::span<const char> reading) mutable -> int {
 			std::string_view correctPart = shouldBe.substr(position, reading.size());
 			doATest(std::string_view(reading.data(), reading.size()), correctPart);
-			position += reading.size();
-			return reading.size();
+			position += static_cast<int>(reading.size());
+			return static_cast<int>(reading.size());
 		};
 
 		{

--- a/ezgz_test.cpp
+++ b/ezgz_test.cpp
@@ -3,6 +3,12 @@
 #include <string>
 #include "ezgz.hpp"
 
+#if EZGZ_HAS_CPP20
+constexpr char kCppVersion[] = "C++20";
+#else
+constexpr char kCppVersion[] = "C++17";
+#endif
+
 template <int Size>
 struct SettingsWithInputSize : EzGz::DefaultDecompressionSettings {
 	constexpr static int inputBufferSize = Size;
@@ -18,7 +24,7 @@ template <int Size>
 struct InputHelper : EzGz::Detail::ByteInput<SettingsWithInputSize<Size>> {
 	InputHelper(std::span<const uint8_t> source)
 	: EzGz::Detail::ByteInput<SettingsWithInputSize<Size>>([source, position = 0] (std::span<uint8_t> toFill) mutable -> int {
-		int filling = static_cast<int>(std::min(source.size() - position, toFill.size()));
+		int filling = int(std::min(source.size() - position, toFill.size()));
 //		std::cout << "Providing " << filling << " bytes of data, " << (source.size() - position - filling) << " left" << std::endl;
 		if(filling != 0)
 			memcpy(toFill.data(), &source[position], filling);
@@ -31,6 +37,9 @@ int main(int, char**) {
 
 	int errors = 0;
 	int tests = 0;
+
+	std::cout << "EzGz Tests (compiled for " << kCppVersion << ")" << std::endl;
+	std::cout << "===============================" << std::endl;
 
 	auto doATest = [&] (auto is, auto shouldBe) {
 		tests++;
@@ -64,7 +73,7 @@ int main(int, char**) {
 		}
 
 		{
-			unsigned int twoBytes = static_cast<unsigned int>(byteReader.getBytes(2));
+			unsigned int twoBytes = unsigned(byteReader.getBytes(2));
 			doATest(twoBytes, 0b1010101010101010u);
 		}
 
@@ -94,7 +103,7 @@ int main(int, char**) {
 			while (read < tryingToRead) {
 				auto readTenBytes = reader.getRange(tryingToRead - read);
 				doATest(readTenBytes.size() < tryingToRead, true);
-				read += static_cast<int>(readTenBytes.size());
+				read += int(readTenBytes.size());
 			}
 			doATest(read, tryingToRead);
 		}
@@ -231,8 +240,8 @@ int main(int, char**) {
 		auto inspectStart = [&doATest, shouldBe, position = 0] (std::span<const char> reading) mutable -> int {
 			std::string_view correctPart = shouldBe.substr(position, reading.size());
 			doATest(std::string_view(reading.data(), reading.size()), correctPart);
-			position += static_cast<int>(reading.size());
-			return static_cast<int>(reading.size());
+			position += int(reading.size());
+			return int(reading.size());
 		};
 
 		{
@@ -419,6 +428,6 @@ int main(int, char**) {
 		}
 	}
 
-	std::cout << "Passed: " << (tests - errors) << " / " << tests << ", errors: " << errors << std::endl;
-	return 0;
+	std::cout << "Passed: " << (tests - errors) << " / " << tests << ", errors: " << errors << std::endl << std::endl;
+	return errors != 0; // if errors, report this back to calling script
 }


### PR DESCRIPTION
These changes fix warnings out of MSVC's highest warning level (and lower ones as well). Most of them fall into the category of adding an explicit `static_cast` when narrowing integer types.

However, there is one change that needs careful review, because I believe it may actually fix a bug of misplaced parentheses. See commit d5a8989 for the change.