### PR TITLE
GitHub action workflow

### DIFF
--- a/.github/workflows/ezgz_test.yml
+++ b/.github/workflows/ezgz_test.yml
@@ -1,0 +1,52 @@
+name: C++ CMake Tests
+
+on:
+    pull_request:
+        branches: [master]
+    push:
+        branches: [master, github-action-workflow]
+jobs:
+  ezgz_test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30  # Set a custom timeout (e.g., 30 minutes)
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        standard: [17, 20] # This corresponds to C++17 and C++20
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up CMake
+      run: |
+        if [ "${{ matrix.os }}" == "windows-latest" ]; then
+          echo "BUILD_DIR=build" >> $GITHUB_ENV
+          echo "EXECUTABLE=build/bin/Release/ezgz_test.exe" >> $GITHUB_ENV
+        else
+          echo "BUILD_DIR=build" >> $GITHUB_ENV
+          echo "EXECUTABLE=build/bin/ezgz_test" >> $GITHUB_ENV
+        fi
+      shell: bash
+
+    - name: Create build directory
+      run: mkdir -p ${{ env.BUILD_DIR }}
+
+    - name: Configure with CMake
+      run: |
+        cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_CXX_STANDARD=${{ matrix.standard }}
+
+    - name: Build with CMake
+      run: |
+        cmake --build ${{ env.BUILD_DIR }} --config Release
+
+    - name: Run Tests
+      run: |
+        if [ "${{ matrix.os }}" == "windows-latest" ]; then
+          ${{ env.EXECUTABLE }}
+        else
+          chmod +x ${{ env.EXECUTABLE }}
+          ./${{ env.EXECUTABLE }}
+        fi
+      shell: bash

--- a/.github/workflows/ezgz_test.yml
+++ b/.github/workflows/ezgz_test.yml
@@ -4,7 +4,7 @@ on:
     pull_request:
         branches: [master]
     push:
-        branches: [master, github-action-workflow]
+        branches: [master]
 jobs:
   ezgz_test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Resolves #7 

This PR request adds a workflow that runs every time a PR is opened against the `master` branch and every time there is a push to the `master` branch. The results appear when this PR is created and for every PR thereafter as long as the workflow is in place.

The workflow builds and runs `ezgz_test` on Ubuntu (GCC), macOS (AppleClang), and Windows (MSVC) for both C++20 and C++17. 

I recommend putting in place a branch protection rule for `master` that requires this workflow to run successfully before a PR can be merged. Here are the steps (courtesy of ChatGPT):

To require that a GitHub Actions workflow completes successfully before a pull request (PR) can be merged, you need to set up **branch protection rules** in the repository settings. These rules enforce that certain checks, like your workflow runs, pass before allowing a PR to be merged.

Here's how you can set it up:

### Steps to Require a Workflow Pass Before Merging a PR:

1. **Go to the Repository Settings**:
   - Navigate to the repository where you want to enforce the rule.
   - Click on the `Settings` tab at the top of the repository page.

2. **Set Up Branch Protection Rules**:
   - In the left-hand menu, click on **Branches** under the "Code and automation" section.
   - Under "Branch protection rules", click **Add rule** (or edit an existing rule if you already have one).

3. **Choose the Branch to Protect**:
   - In the **Branch name pattern** field, specify the branch you want to protect. Usually, you would protect the `main` or `master` branch (the default branch).
   - For example, enter `main` to protect the `main` branch.

4. **Enable Status Checks**:
   - Check the box for **Require status checks to pass before merging**.
   - This will allow you to specify which checks must pass before a PR can be merged.

5. **Select the Workflow(s) to Require**:
   - After enabling **Require status checks to pass before merging**, you'll see an option to select which checks are required.
   - In this list, look for your workflow. The workflow that runs in the PR (defined in your `.github/workflows/` directory) should appear in this list.
   - Select the checkbox next to the workflow you want to require to pass. It will typically be listed by the name of the job in your workflow file (e.g., `CI`, `build`, etc.).

6. **Optional: Additional Settings**:
   - You can also enable other settings like:
     - **Require branches to be up to date before merging** (ensures that the PR is up to date with the target branch).
     - **Include administrators** (forces admins to comply with the branch protection rules).

7. **Save the Rule**:
   - After configuring the settings, click **Create** or **Save changes**.

### Example Configuration:
If you configured your GitHub Actions workflow to run on pull requests to the `main` branch, and you named the job `build`, you'll see `build` as an option in the **Status checks** section of the protection rule settings.

### Summary:
By setting up branch protection rules, you ensure that a pull request cannot be merged unless the workflow (or specific jobs within it) completes successfully. This is a great way to enforce CI/CD best practices and prevent unverified code from being merged.